### PR TITLE
Fix version and limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function hexo_generator_json_feed(site) {
       return post.published;
     });
 
-    if (config.limit) posts = posts.splice(0, config.limit);
+    if (config.limit) posts = posts.limit(0, config.limit);
 
     siteAuthor = {
 		name: hexo.config.author,
@@ -49,7 +49,7 @@ function hexo_generator_json_feed(site) {
     });
 
 	feedContent = {
-		version: 1,
+		version: 'https://jsonfeed.org/version/1',
 		title: hexo.config.title,
 		description: hexo.config.description,
 		home_page_url: hexo.config.url,

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function hexo_generator_json_feed(site) {
       return post.published;
     });
 
-    if (config.limit) posts = posts.limit(0, config.limit);
+    if (config.limit) posts = posts.limit(config.limit);
 
     siteAuthor = {
 		name: hexo.config.author,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-json-feed-org",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Hexo plugin to generate a JSON feed as per the jsonfeed.org specification",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/rmlewisuk/hexo-generator-json-feed-org#readme",
   "dependencies": {
-    "hexo-util": "latest"
+    "hexo-util": "^0.6.2"
   }
 }


### PR DESCRIPTION
According to [JSON Feed Spec](https://jsonfeed.org/version/1), the version should be the URL `https://jsonfeed.org/version/1 `. This could fix compatibility issues with clients such as Inoreader.